### PR TITLE
Fix: housecleanup.sqf. Medic gear/licenses. House sellbuy-dupe, Civ info

### DIFF
--- a/@extDB/extdb/db_custom/altis-life-rpg-4.ini
+++ b/@extDB/extdb/db_custom/altis-life-rpg-4.ini
@@ -295,7 +295,7 @@ SQL1_1 = SELECT playerid, name, cash, bankacc, adminlevel, donatorlvl, civ_licen
 SQL1_INPUTS = 1
 
 Number of Inputs = 1
-OUTPUT = 1-String, 2-String, 3, 4, 5-String, 6-String, 7-AltisLifeRPG_Array, 8-String, 9-AltisLifeRPG_Array
+OUTPUT = 1-String, 2-String, 3, 4, 5-String, 6-String, 7-AltisLifeRPG_Array, 8, 9-AltisLifeRPG_Array
 
 ;;______________________________________________________________
 [playerIndependentInfo]
@@ -547,8 +547,8 @@ Number of Inputs = 3
 
 SQL1_1 = UPDATE vehicles SET alive=? WHERE pid=? AND id=?;
 
-SQL1_INPUTS = 1, 2
-Number of Inputs = 2
+SQL1_INPUTS = 1, 2, 3
+Number of Inputs = 3
 
 
 ;;______________________________________________________________
@@ -620,7 +620,7 @@ OUTPUT = 1
 ;;______________________________________________________________
 [housingSellHouse]
 ;;
-SQL1_1 = UPDATE houses SET owned='0', pos='[]' WHERE pid=? AND pos=? AND owned='1';
+SQL1_1 = UPDATE houses SET owned='0', pos='[]', inventory='[[],0]', containers='[]' WHERE pid=? AND pos=? AND owned='1';
 SQL1_INPUTS = 1, 2, 3
 
 Number of Inputs = 3
@@ -628,7 +628,7 @@ Number of Inputs = 3
 ;;______________________________________________________________
 [housingSellHouse2]
 ;;
-SQL1_1 = UPDATE houses SET owned='0', pos='[]' WHERE id=?;
+SQL1_1 = UPDATE houses SET owned='0', pos='[]', inventory='[[],0]', containers='[]' WHERE id=?;
 SQL1_INPUTS = 1
 
 Number of Inputs = 1

--- a/@extDB/extdb/db_custom/altis-life-rpg-4.ini
+++ b/@extDB/extdb/db_custom/altis-life-rpg-4.ini
@@ -657,6 +657,8 @@ SQL1_INPUTS = 1
 
 Number of Inputs = 1
 
+OUTPUT = 1-String, 2-String, 3-AltisLifeRPG_Array, 4-AltisLifeRPG_Array
+
 ;;**************************************************************
 ;;**************************************************************
 ;; Wanted System

--- a/extDB-Build/life_server/Functions/MySQL/fn_updateRequest.sqf
+++ b/extDB-Build/life_server/Functions/MySQL/fn_updateRequest.sqf
@@ -30,7 +30,7 @@ for "_i" from 0 to count(_licenses)-1 do {
 switch (_side) do {
 	case west: {_query = format["playerWestUpdate:%1:%2:%3:%4:%5:%6",_name,_cash,_bank,_gear,_licenses,_uid];};
 	case civilian: {_query = format["playerCivilianUpdate:%1:%2:%3:%4:%6:%7:%5",_name,_cash,_bank,_licenses,_uid,_gear,[_this select 7] call DB_fnc_bool];};
-	case independent: {_query = format["playerWestUpdate:%1:%2:%3:%4:%6:%5",_name,_cash,_bank,_licenses,_uid,_gear];};
+	case independent: {_query = format["playerIndependentUpdate:%1:%2:%3:%4:%6:%5",_name,_cash,_bank,_licenses,_uid,_gear];};
 };
 
 waitUntil {sleep (random 0.3); !DB_Async_Active};


### PR DESCRIPTION
--MEDIC GEAR/LICENSES--
I added a fix for the medics (their clothing/licenses where saving in the wrong columns (for cops)) so it broke the cop login as they had mediclicenses as gear. Make sure the number %4 and %5 is corresponding with med_gear and med_licenses in your database, else switch them around.

--CIVINFO--
Returns arrested without -string to it. As arrested is a 1 or 0. Solves some RPT errors for me regarding Arrested/getting stuck on loading into the server. And also, everywhere else in the ExtDB ini its used w/o -string, i think this fix was mentioned on the forums to! 

--HOUSE SELL/BUY DUPE FIX--
Also a fix for the houses. When they are sold and bought the same restart, people get the inventory of the boxes when they place new cargoboxes (if it happens same restart, thats a MAJOR dupe source). With this fix you dont have that issue anymore as the sell querys will wipe inventory and boxes to so when they are bought, they are truly empty.


--HOUSECLEANUP ERROR--
Ive had alot of issues when people disconnect from the server. 
(Edit: In my database the houses are populated)
The RPT errors is referring to:

File life_server\Functions\MySQL\fn_asyncCall.sqf, line 62
Error Invalid number in expression
File life_server\Functions\Housing\fn_houseCleanup.sqf, line 12
Error Undefined variable in expression: _houses

And this is how i solved it, i simply added the sql output to the
[housecleanup] array in altis-life-rpg-4.ini as the fn_housecleanup.sqf
is expecting a value, with no strange things in it, in return. The array looks the same as
[housingFetchPlayerHouse] so i guess its also possible to point towards
that one, but lets try to do it right! If this is right that is! :) . 

This is my try to contribute with something after spending tons of late nights on this! thanks
itsyuka for everything and ofc tonic and those around helping!