### PR TITLE
Update fn_vehInvSearch.sqf

### DIFF
--- a/extDB-Build/Altis_Life.Altis/core/cop/fn_vehInvSearch.sqf
+++ b/extDB-Build/Altis_Life.Altis/core/cop/fn_vehInvSearch.sqf
@@ -48,7 +48,7 @@ if(_value > 0) then {
 /*
 //just saving default code
 #include <macro.h>
-//File: fn_vehInvSearch.sqf Author: Bryan "Tonic" Boardwine Description:Searches the vehicle for illegal items.*/
+//File: fn_vehInvSearch.sqf Author: Bryan "Tonic" Boardwine Description:Searches the vehicle for illegal items.
 private["_vehicle","_vehicleInfo","_value","_list"];
 _vehicle = cursorTarget;
 _list = ["Air","Ship","LandVehicle"];


### PR DESCRIPTION
Warning with */ because the saving is called and the last line (*/) make an problem in rpt